### PR TITLE
Fix error caused by calling gsub! on some classnames

### DIFF
--- a/app/controllers/teachers/classrooms_controller.rb
+++ b/app/controllers/teachers/classrooms_controller.rb
@@ -84,7 +84,7 @@ class Teachers::ClassroomsController < ApplicationController
         pdf = LoginPdf.new(@classroom)
         # we want to sanitize the classroom name so it works as a file name
         # this will get rid of illegal characters and replace them with underscores
-        filename = @classroom.name.gsub!(/[^0-9A-Za-z.\-]/, '_')
+        filename = @classroom.name.gsub(/[^0-9A-Za-z.\-]/, '_')
         send_data pdf.render, filename: "quill_logins_for_#{filename.downcase}.pdf", type: "application/pdf"
       end
     end


### PR DESCRIPTION
Removed bang on gsub as we are not trying to rename the classroom, just create a new string for the filename variable. This was causing an error for some classnames.